### PR TITLE
Add default SECURITY.md for CycloneDX organisation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Reporting Security Issues
+
+The CycloneDX team and community take security bugs seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, email [security@cyclonedx.org](mailto:security@cyclonedx.org) and include the word "SECURITY" in the subject line.
+
+The CycloneDX team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party modules to the person or team maintaining the module.


### PR DESCRIPTION
For #3 

@stevespringett taken from the DT repo. Is there a security@cyclonedx.org email address?