### PR TITLE
The part regarding sign-off should be more specific

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,8 @@ Please follow these rules when writing a commit message:
 - Use the imperative mood in the subject line
 - Wrap the body at 72 characters
 - Use the body to explain what and why vs. how
-- Commits must be signed off to indicate agreement with [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
-  To sign-off include `Signed-off-by: Author Name <authoremail@example.com>` in every commit message.
+- Commits must be signed off to indicate agreement with [Developer Certificate of Origin (DCO)](https://developercertificate.org/).  
+  To sign-off include `Signed-off-by: Author Name <authoremail@example.com>` in every commit message.  
   You can do this automatically by using git's `-s` flag (i.e., `git commit -s`).
   
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,5 +56,5 @@ Please follow these rules when writing a commit message:
 - Commits must be signed off to indicate agreement with [Developer Certificate of Origin (DCO)](https://developercertificate.org/).  
   To sign-off include `Signed-off-by: Author Name <authoremail@example.com>` in every commit message.  
   You can do this automatically by using git's `-s` flag (i.e., `git commit -s`).
-  
+
 [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) is a greate guide to writing good commit messages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,5 +57,4 @@ Please follow these rules when writing a commit message:
   To sign-off include `Signed-off-by: Author Name <authoremail@example.com>` in every commit message.  
   You can do this automatically by using git's `-s` flag (i.e., `git commit -s`).
   
-
 [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) is a greate guide to writing good commit messages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,9 @@ Please follow these rules when writing a commit message:
 - Use the imperative mood in the subject line
 - Wrap the body at 72 characters
 - Use the body to explain what and why vs. how
-- Always include `Signed-off-by: Author Name <authoremail@example.com>` in every commit message.  
+- Commits must be signed off to indicate agreement with [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+  To sign-off include `Signed-off-by: Author Name <authoremail@example.com>` in every commit message.
   You can do this automatically by using git's `-s` flag (i.e., `git commit -s`).
+  
 
 [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) is a greate guide to writing good commit messages.


### PR DESCRIPTION
Currently, contributors are requested to sign off their commits, but this document doesn't say why.

This leave a scenario open, in which they sign off, but claim later that it was signed off erroneously, as they weren't explained what it actually means but were just told to do so. With this extra line, every contributor should be aware of the legal implication.

Multiple CycloneDX projects reference this page for contribution guidelines.